### PR TITLE
Move arg `Reason` from Rejected to FilteredOut

### DIFF
--- a/bidding.org
+++ b/bidding.org
@@ -34,10 +34,10 @@ mind.
 *** Rejections
 **** FilteredOut
      Early filtering removed the offer
-     FilteredOut(AuctionId, Id, AgentId)
+     FilteredOut(AuctionId, Id, AgentId, Reason)
 **** Rejected
      The third-party provider rejected the offer on their end
-     Rejected(AuctionId, Id, AgentId, Reason)
+     Rejected(AuctionId, Id, AgentId)
 *** Errors
 **** PartnerError
      The agent backend returned an error


### PR DESCRIPTION
When we filter out a customer from sending a request to an agent/service, we will know why it was filtered out and we can include this in our response. The same does not (usually) hold for rejects from a third party such as a bank. We will, in most cases, only received that the application was rejected without knowing for what reasons. There are of course cases where a bank will respond with a reject reason, for example when a credit note is found for the customer and a bank do not know deal with customers with a credit note. It can be discussed whether a `Rejected` event should have an optional _Reason_ or not, but I think that a FilteredOut event should contain a _Reason_.